### PR TITLE
Allow juju2client to start on a blank canvas

### DIFF
--- a/charms/layers/juju2-client/reactive/juju2-client.py
+++ b/charms/layers/juju2-client/reactive/juju2-client.py
@@ -43,24 +43,30 @@ def set_juju_installed_state():
 @when('config.changed.credentials.yaml')
 def import_credentials():
     credentials_file = "{}/.local/share/juju/credentials.yaml".format(HOME)
-    credentials = yaml.load(b64decode(config()['credentials.yaml']))
-    merge_yaml_file_and_dict(credentials_file, credentials)
+    data = config()['credentials_yaml']
+    if data != '':
+        credentials = yaml.load(b64decode(data))
+        merge_yaml_file_and_dict(credentials_file, credentials)
     set_state('juju.credentials.available')
 
 @when('juju.installed')
 @when('config.changed.controllers.yaml')
 def import_controllers():
     controllers_file = "{}/.local/share/juju/controllers.yaml".format(HOME)
-    controllers = yaml.load(b64decode(config()['controllers.yaml']))
-    merge_yaml_file_and_dict(controllers_file, controllers)
+    data = config()['controllers_yaml']
+    if data != '':
+        controllers = yaml.load(b64decode(data))
+        merge_yaml_file_and_dict(controllers_file, controllers)
     set_state('juju.controller.available')
 
 @when('juju.installed')
 @when('config.changed.clouds.yaml')
 def import_clouds():
     clouds_file = "{}/.local/share/juju/clouds.yaml".format(HOME)
-    clouds = yaml.load(b64decode(config()['clouds.yaml']))
-    merge_yaml_file_and_dict(clouds_file, clouds)
+    data = config()['clouds_yaml']
+    if data != '':
+        clouds = yaml.load(b64decode(data))
+        merge_yaml_file_and_dict(clouds_file, clouds)
     set_state('juju.cloud.available')
 
 def merge_yaml_file_and_dict(filepath, datadict):


### PR DESCRIPTION
Now the charm install fails when installing without controller/clouds/credential.yaml passed to the config. This is a minor fix to allow setting up a blank juju environment.